### PR TITLE
[#69] 결제 취소 기능 구현

### DIFF
--- a/src/main/java/flab/delideli/controller/PaymentController.java
+++ b/src/main/java/flab/delideli/controller/PaymentController.java
@@ -12,10 +12,10 @@ import flab.delideli.service.payment.PaymentService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -52,6 +52,14 @@ public class PaymentController {
 		orderService.doesOrderIdAndUserIdExist(orderId, userId);
 
 		return commonPaymentService.getPaymentSummary(orderId, userId);
+	}
+
+	@PatchMapping("/{paymentId}")
+	@ApiOperation(value = "결제 상태를 CANCELED로 업데이트")
+	@LoginUserLevel(role = UserLevel.MEMBER_LEVEL)
+	public void cancelPayment(@PathVariable("paymentId") long paymentId,
+		@CurrentUser String userId) {
+		commonPaymentService.cancelPayment(paymentId, userId);
 	}
 
 }

--- a/src/main/java/flab/delideli/dao/PaymentDao.java
+++ b/src/main/java/flab/delideli/dao/PaymentDao.java
@@ -8,4 +8,6 @@ public interface PaymentDao {
 
 	PaymentDTO selectPaymentSummary(long orderId, String userId);
 
+	void updatePaymentStatusCanceled(long paymentId, String userId);
+
 }

--- a/src/main/resources/mappers/PaymentMapper.xml
+++ b/src/main/resources/mappers/PaymentMapper.xml
@@ -22,5 +22,11 @@
     <result column="pay_status" property="paymentStatus"></result>
     <result column="pay_date" property="paymentDate"></result>
   </resultMap>
+  
+  <update id="updatePaymentStatusCanceled">
+    UPDATE payments
+    SET pay_status = 'CANCELED'
+    WHERE payment_id = #{paymentId} AND user_id = #{userId}
+  </update>
 
 </mapper>


### PR DESCRIPTION
- 페어 프로그래밍으로 작업한 이슈입니다.

<요구사항>
- 결제를 취소할 경우 데이터베이스의 결제 상태를 CANCELED로 교체하는 UPDATE문을 실행한다.
-1. 이전 결제 상태가 BEFORE_CHECKED 또는 CONFIRMED인 경우 결제 취소가 실행될 수 있다.
-2. 이전 결제 상태가 CONFIRMED_UNABLE_TO_CANCEL인 경우에는 결제 취소가 불가능하다.
- 결제 취소가 불가능할 경우(1-2.) UPDATE문을 실행하지 않고, `IllegalStatementException` 예외가 발생한다.
- 결제 취소 로직은 결제 번호와 유저 아이디를 매개변수로 넘겨준다.
- paymentId의 값이 null이어서는 안 된다.
- userId의 값이 null이어서는 안 된다.
- 유저는 자신의 주문에 대한 결제 취소만 가능하다.
-1. 주문 번호와 아이디로 주문 테이블을 조회한 후 조회 결과가 없으면 `IlleagalArgumentException`이 발생한다.